### PR TITLE
feat: add API for versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,4 @@ time = "0.3.17"
 [build-dependencies]
 tonic-build = { version = "0.8", features = ["prost"] }
 prost-build = { version = "0.11.2" }
+chrono = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
+use chrono::{DateTime, SecondsFormat, Utc};
 use std::io::Result;
+use std::process::Command;
 
 fn main() -> Result<()> {
     tonic_build::configure()
@@ -82,6 +84,25 @@ fn main() -> Result<()> {
         ],
         &["proto"],
     )?;
+
+    // build information
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0"])
+        .output()
+        .unwrap();
+    let git_tag = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_VERSION={}", git_tag);
+
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_commit = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_COMMIT={}", git_commit);
+
+    let now: DateTime<Utc> = Utc::now();
+    let build_date = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+    println!("cargo:rustc-env=GIT_DATE={}", build_date);
 
     Ok(())
 }

--- a/src/handler/http/request/mod.rs
+++ b/src/handler/http/request/mod.rs
@@ -1,11 +1,11 @@
 pub mod alerts;
 pub mod dashboards;
 pub mod functions;
-pub mod health;
 pub mod ingest;
 pub mod organization;
 pub mod prom;
 pub mod search;
+pub mod status;
 pub mod stream;
 pub mod traces;
 pub mod users;

--- a/src/handler/http/request/status/mod.rs
+++ b/src/handler/http/request/status/mod.rs
@@ -11,10 +11,26 @@ struct HealthzResponse {
     status: String,
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct VersionResponse {
+    version: String,
+    commit: String,
+    date: String,
+}
+
 #[get("/healthz")]
 pub async fn healthz() -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok().json(HealthzResponse {
         status: "ok".to_string(),
+    }))
+}
+
+#[get("/versions")]
+pub async fn versions() -> Result<HttpResponse, Error> {
+    Ok(HttpResponse::Ok().json(VersionResponse {
+        version: config::VERSION.to_string(),
+        commit: config::COMMIT_HASH.to_string(),
+        date: config::BUILD_DATE.to_string(),
     }))
 }
 

--- a/src/handler/http/router/mod.rs
+++ b/src/handler/http/router/mod.rs
@@ -9,11 +9,11 @@ use super::auth::validator;
 use super::request::alerts::*;
 use super::request::dashboards::*;
 use super::request::functions;
-use super::request::health::{cache_status, healthz};
 use super::request::ingest;
 use super::request::organization::*;
 use super::request::prom::*;
 use super::request::search;
+use super::request::status;
 use super::request::stream;
 use super::request::traces::*;
 use super::request::users;
@@ -24,7 +24,7 @@ pub mod ui;
 
 pub fn get_routes(cfg: &mut web::ServiceConfig) {
     let auth = HttpAuthentication::basic(validator);
-    cfg.service(healthz);
+    cfg.service(status::healthz).service(status::versions);
 
     let cors = Cors::default()
         .send_wildcard()
@@ -48,7 +48,7 @@ pub fn get_routes(cfg: &mut web::ServiceConfig) {
         web::scope("/api")
             .wrap(auth)
             .wrap(cors)
-            .service(cache_status)
+            .service(status::cache_status)
             .service(ingest::bulk)
             .service(ingest::multi)
             .service(ingest::json)

--- a/src/infra/config.rs
+++ b/src/infra/config.rs
@@ -12,11 +12,14 @@ use crate::meta::functions::{FunctionList, Transform};
 use crate::meta::prom::ClusterLeader;
 use crate::meta::user::User;
 
+pub static VERSION: &str = env!("GIT_VERSION");
+pub static COMMIT_HASH: &str = env!("GIT_COMMIT");
+pub static BUILD_DATE: &str = env!("GIT_DATE");
+
 lazy_static! {
     pub static ref CONFIG: Config = init();
     pub static ref LOCKER: DashMap<String, std::sync::Mutex<bool>> = DashMap::new();
     pub static ref INSTANCE_ID: DashMap<String, String> = DashMap::new();
-    pub static ref VERSION: &'static str = env!("CARGO_PKG_VERSION");
     pub static ref TELEMETRY_CLIENT: segment::HttpClient = segment::HttpClient::new(
         Client::builder()
             .connect_timeout(Duration::new(10, 0))


### PR DESCRIPTION
Add versions API:

Endpoint: `GET /versions`

Response:

```
{
	"version": "v0.0.1",
	"commit": "410e5cd4071f05c8840aabfed690239bf2daffcd",
	"date": "2023-02-13T02:15:43Z"
}
```